### PR TITLE
fix: indentation in `starting-a-unit` list

### DIFF
--- a/src/guides/starting-a-unit.md
+++ b/src/guides/starting-a-unit.md
@@ -14,18 +14,18 @@ With those two out of the way, make sure you have fulfilled these requirements:
 
 - At least three active members to start with.
 
-There is no upper bound to the number of members of course.
+    There is no upper bound to the number of members of course.
 
 - A publicly available organisation page.
 
-This can be a website, GitHub or GitLab organisation, or any platform that can host your activities, and from which people can learn about your Unit.
+    This can be a website, GitHub or GitLab organisation, or any platform that can host your activities, and from which people can learn about your Unit.
 
-You will be responsible for your own branding and expression. As a Unit, you have full autonomy over everything you do and how your community is managed, the only caveat being,
+    You will be responsible for your own branding and expression. As a Unit, you have full autonomy over everything you do and how your community is managed, the only caveat being,
 
 - You must adopt a properly enforced Code of Conduct.
 
-We have made this easy for you. If you do not explicitly create or adopt your own Code of Conduct, our [Unit Code of Conduct](unit-code-of-conduct.md) will apply to your Unit. You must have your Code of Conduct publicly accessible in your Unit's organisation page.
+    We have made this easy for you. If you do not explicitly create or adopt your own Code of Conduct, our [Unit Code of Conduct](unit-code-of-conduct.md) will apply to your Unit. You must have your Code of Conduct publicly accessible in your Unit's organisation page.
 
 - You must have a public email address associated with your Unit.
 
-This is to ensure that you can be contacted reliably, and also so that people have an outlet to report Code of Conduct violations.
+    This is to ensure that you can be contacted reliably, and also so that people have an outlet to report Code of Conduct violations.


### PR DESCRIPTION
Edit: not much has changed here, but I thought it would be nice to separate this change from other changes, hence the PR

The bullet points in "8. Starting your own unit" looked weird, the
content after each of the point headings were indented back to the
beginning which made the distinction between points hard to see.
Fixed those by indenting all of the content after the points by 4
spaces.