### PR TITLE
SEO - add google site verification marker file

### DIFF
--- a/src/google51f713c4fe9fadd0.html
+++ b/src/google51f713c4fe9fadd0.html
@@ -1,0 +1,1 @@
+google-site-verification: google51f713c4fe9fadd0.html


### PR DESCRIPTION
It looks a little ugly in the `src/` directory along with the other files
being nicely named. This is probably better than the alternative of
adding a meta tag to every page by overriding `theme/head.hbs`. The other
alternatives for verification are DNS records and google analytics, both
of which are not feasible or desirable at the moment.

Note: this verification tag is tied to my Google account at this time.